### PR TITLE
Better error message for email failure

### DIFF
--- a/userdb.php
+++ b/userdb.php
@@ -388,6 +388,10 @@ function pingUser(&$auth_sock, $uname, $email, $code, &$complaint) {
       Header("Location: login.php");
       return FALSE;
    }
+   if ($problem == "email failed" || $problem == "ping failed") {
+      $complaint = "There was an error sending your email verification message. Your account was created correctly. Please contact support to manually verify your email or wait and try to change your email again yourself.";
+      return FALSE;
+   }
    $complaint = "UserDB error: " . $problem;
    return FALSE;
 }


### PR DESCRIPTION
When email can't successfully be sent, like on a random Linode account, it's nice to have a more verbose error message. Otherwise we just get "UserDB error: email failed".